### PR TITLE
Add refuse_boss_task scene and improve story narrative flow

### DIFF
--- a/STORY_FLOW.md
+++ b/STORY_FLOW.md
@@ -5,8 +5,8 @@
 
 ## ストーリー統計
 
-- **総シーン数**: 113
-- **到達可能シーン数**: 113
+- **総シーン数**: 114
+- **到達可能シーン数**: 114
 - **到達不可能シーン数**: 0
 - **総エンディング数**: 31
   - グッドエンド: 3 (到達可能: 3)
@@ -75,6 +75,7 @@ graph TD
   talk_to_boss_comment_break{"渋々部長の元へ行く。どうせいつもの無茶振"}
   talk_to_boss_ignore{"渋々部長の元へ行く。どうせいつもの無茶振"}
   receive_document_task{"「……えっ」渡されたのは大量の資料。もう"}
+  refuse_boss_task{"勇気を振り絞って、部長に逆らった。  そ"}
   accept_task_reluctantly{"とはいえ自分に拒否権などあるわけがない。"}
   laugh_off_and_work{"「ははは……そうですね」と適当に笑って誤"}
   ask_junior_for_help{"今年入ったばかりの新人で、気立てが良い。"}
@@ -195,7 +196,7 @@ graph TD
   leave_confidently -->|"労働基準監督署に相談する"| labor_inspection
   leave_confidently -->|"そのまま転職活動を始める"| job_search_burnout
   leave_confidently -->|"今日の解放感を噛み締める"| eat_overtime_bread
-  eat_overtime_bread -->|"タクシーで帰る（自腹）"| taxi_home
+  eat_overtime_bread -->|"タクシーで帰る"| taxi_home
   eat_overtime_bread -->|"同期に愚痴をこぼす"| complain_to_colleague
   eat_overtime_bread -->|"部長に呼ばれる"| talk_to_boss_comment_break
   taxi_home -->|"転職活動を本格化する"| job_search_burnout
@@ -204,8 +205,8 @@ graph TD
   complain_to_colleague -->|"一緒に転職活動をする"| joint_job_hunting
   complain_to_colleague -->|"労働組合について調べる"| research_union
   complain_to_colleague -->|"まずは自分だけで行動する"| job_search_burnout
-  joint_job_hunting -->|"本格的に転職活動を開始する"| job_search_burnout
-  joint_job_hunting -->|"転職エージェントに相談する"| job_search_burnout
+  joint_job_hunting -->|"準備不足のまま転職活動を開始す..."| job_search_burnout
+  joint_job_hunting -->|"焦って転職エージェントに駆け込..."| job_search_burnout
   joint_job_hunting -->|"まず労働環境改善を試みる"| research_union
   talk_to_boss_comment_break -->|"資料作成の仕事を受ける"| receive_document_task
   talk_to_boss_comment_break -->|"暑気払いの準備を手伝う"| receive_document_task
@@ -214,8 +215,11 @@ graph TD
   talk_to_boss_ignore -->|"プレゼン資料の作成を受ける"| receive_document_task
   talk_to_boss_ignore -->|"週末出社の指示を受ける"| receive_document_task
   receive_document_task -->|"わかりました……"| accept_task_reluctantly
-  receive_document_task -->|"なぜ今日中なんですか？"| procrastinate
-  receive_document_task -->|"無理です"| procrastinate
+  receive_document_task -->|"なぜ今日中なんですか？"| refuse_boss_task
+  receive_document_task -->|"無理です"| refuse_boss_task
+  refuse_boss_task -->|"弁護士に相談して法的に戦う"| consult_lawyer_first
+  refuse_boss_task -->|"労働組合の結成を検討する"| research_union
+  refuse_boss_task -->|"労働基準監督署に駆け込む"| labor_inspection
   accept_task_reluctantly -->|"よし殴ろう"| punch_boss
   accept_task_reluctantly -->|"適当に笑って誤魔化す"| laugh_off_and_work
   accept_task_reluctantly -->|"無視して仕事に戻る"| laugh_off_and_work
@@ -228,14 +232,15 @@ graph TD
   ask_colleague_for_help -->|"一緒に作業して仕上げる"| work_with_junior
   ask_colleague_for_help -->|"後輩も巻き込んで3人で仕上げる"| work_with_junior
   ask_colleague_for_help -->|"やっぱり迷惑かけたくない"| work_alone_suffer
-  work_with_junior -->|"断固として断る"| procrastinate
+  work_with_junior -->|"断固として断る"| refuse_boss_task
   work_with_junior -->|"仕方なく付き合う"| attend_drinking_with_boss
   work_with_junior -->|"30分だけなら"| thirty_minutes_condition
-  attend_drinking_with_boss -->|"反論する"| procrastinate
+  attend_drinking_with_boss -->|"反論する"| refuse_boss_task
   attend_drinking_with_boss -->|"黙って聞く"| listen_silently_to_lecture
-  attend_drinking_with_boss -->|"席を立つ"| procrastinate
-  listen_silently_to_lecture -->|"お互い頑張ろうな"| parting_and_cry_then_jobhunt
-  listen_silently_to_lecture -->|"こんな会社もう嫌だ"| procrastinate
+  attend_drinking_with_boss -->|"席を立つ"| refuse_boss_task
+  listen_silently_to_lecture -->|"お互い転職活動しようか"| parting_and_cry_then_jobhunt
+  listen_silently_to_lecture -->|"一人で頑張るしかない"| work_alone_suffer
+  listen_silently_to_lecture -->|"もう限界だ..."| mental_breakdown
   research_union -->|"慎重にメンバーを集める"| union_member_recruitment
   research_union -->|"やっぱり転職の方が安全かも"| job_search_burnout
   research_union -->|"労基署に相談してみる"| labor_inspection
@@ -305,8 +310,8 @@ graph TD
   lawyer_strategy_meeting -->|"自分の意見を強く主張する"| client_lawyer_conflict
   lawyer_strategy_meeting -->|"消極的で任せきりにする"| lawyer_strategy_meeting_rushed
   lawyer_strategy_meeting_rushed -->|"この条件で交渉開始"| lawyer_individual_negotiation
-  plan_anonymous_report -->|"証拠を集める（慎重に進める）"| gather_evidence_carefully
-  plan_anonymous_report -->|"給与明細だけで申告する（急ぐ）"| report_with_minimal_evidence
+  plan_anonymous_report -->|"証拠を集める"| gather_evidence_carefully
+  plan_anonymous_report -->|"給与明細だけで申告する"| report_with_minimal_evidence
   plan_anonymous_report -->|"同期にも証拠集めを手伝ってもら..."| gather_evidence_with_colleague
   lawyer_group_negotiation -->|"強気で全面的な改善を要求"| lawyer_demanding_negotiation
   lawyer_group_negotiation -->|"段階的改善案を提示"| lawyer_gradual_plan
@@ -360,7 +365,7 @@ graph TD
   lawyer_push_further -->|"最終提案を受け入れる"| lawyer_accept_compromise
   lawyer_push_further -->|"裁判を決行する"| lawyer_litigation_threat
   lawyer_gradual_success -->|"労働組合を結成して全社改革を目..."| union_member_recruitment
-  lawyer_gradual_success -->|"この改善で満足する"| moderate_improvement_ending
+  lawyer_gradual_success -->|"ここで戦いを終える"| moderate_improvement_ending
   lawyer_gradual_success -->|"改善の進捗を監視し続ける"| monitor_company_improvement
   lawyer_set_deadlines -->|"改善の進捗を確認する"| lawyer_gradual_success
   lawyer_set_deadlines -->|"毎月の監視体制を整える"| monitor_company_improvement
@@ -381,9 +386,9 @@ graph TD
   wait_investigation_results -->|"弁護士に依頼して個人で戦う"| consult_lawyer_first
   wait_investigation_results -->|"この程度の改善で満足する"| moderate_improvement_ending
   monitor_company_improvement -->|"さらに組合を全社に拡大して根本..."| union_member_recruitment
-  monitor_company_improvement -->|"この改善で満足して働き続ける"| moderate_improvement_ending
-  monitor_company_improvement -->|"改善された経験を活かして転職"| job_search_burnout
-  continue_improved_company -->|"この改善に満足する"| moderate_improvement_ending
+  monitor_company_improvement -->|"この成果で妥協する"| moderate_improvement_ending
+  monitor_company_improvement -->|"せっかくの改善を捨てて転職に踏..."| job_search_burnout
+  continue_improved_company -->|"ここでひと区切りつける"| moderate_improvement_ending
   procrastinate -->|"毎日残業を続ける"| accept_overtime_daily
   procrastinate -->|"今からでも転職活動を始める"| job_search_burnout
   procrastinate -->|"労働組合を作ろうと決意"| research_union

--- a/src/data/story.ts
+++ b/src/data/story.ts
@@ -119,7 +119,7 @@ export const storyData: StoryDataType = {
     "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
-      { "text": "準備不足のまま転職活動を開始する", "next": "job_search_burnout" },
+      { "text": "勢いで本格的に転職活動を始める", "next": "job_search_burnout" },
       { "text": "焦って転職エージェントに駆け込む", "next": "job_search_burnout" },
       { "text": "まず労働環境改善を試みる", "next": "research_union" }
     ]
@@ -912,7 +912,7 @@ export const storyData: StoryDataType = {
   },
 
   "accept_overtime_daily": {
-    "text": "毎日の残業を受け入れることにした。\n\n「残業は当たり前。これがサラリーマンの人生か」\n\n毎晩23時まで仕事。コンビニのパン、カップ麺が夕食。\n\n体は疲弊し始める。\n\n「肩も凝るし、頭痛も毎日...」\n\n健康診断では要検査判定が出た。",
+    "text": "毎日の残業を受け入れることにした。\n\n「残業は当たり前。これがサラリーマンの人生か」\n\nそうして数ヶ月が過ぎた。\n\n毎晩23時まで仕事。コンビニのパン、カップ麺が夕食。土日も気が休まらず、月曜の朝にはまた憂鬱が押し寄せる。\n\n気付けば、体は確実に蝕まれていた。\n\n「肩も凝るし、頭痛も毎日...」\n\n直近の健康診断では、要検査判定が出ていた。",
     "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [

--- a/src/data/story.ts
+++ b/src/data/story.ts
@@ -119,8 +119,8 @@ export const storyData: StoryDataType = {
     "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
-      { "text": "本格的に転職活動を開始する", "next": "job_search_burnout" },
-      { "text": "転職エージェントに相談する", "next": "job_search_burnout" },
+      { "text": "準備不足のまま転職活動を開始する", "next": "job_search_burnout" },
+      { "text": "焦って転職エージェントに駆け込む", "next": "job_search_burnout" },
       { "text": "まず労働環境改善を試みる", "next": "research_union" }
     ]
   },
@@ -153,8 +153,19 @@ export const storyData: StoryDataType = {
     "bgm": "/bgm/n43.mp3",
     "choices": [
       { "text": "わかりました……", "next": "accept_task_reluctantly" },
-      { "text": "なぜ今日中なんですか？", "next": "procrastinate" },
-      { "text": "無理です", "next": "procrastinate" }
+      { "text": "なぜ今日中なんですか？", "next": "refuse_boss_task" },
+      { "text": "無理です", "next": "refuse_boss_task" }
+    ]
+  },
+
+  "refuse_boss_task": {
+    "text": "勇気を振り絞って、部長に逆らった。\n\nその瞬間、部長の顔から笑いが消えた。\n\n「……ふーん。お前、そういうスタンスなんだ」\n\n短く返されただけだったが、空気が凍るのが分かった。何か嫌な予感がする。\n\n翌週から、部長の態度はあからさまに変わった。\n\n大事な会議には呼ばれない。評価面談では「協調性に欠ける」と書かれる。誰でもできる雑用ばかり押し付けられ、本来の業務からは外された。隣の席の同期も、部長を恐れて目を合わせなくなった。\n\n「これ、完全に閑職に追いやられてるよな……」\n\nだが、冷静に振り返れば、これは典型的なパワハラの手口だ。報復人事、無視、過小評価——全部、立派な不当労働行為と言える。\n\n泣き寝入りする義理はない。むしろ、ここからが反撃の始まりだ。",
+    "background": "/images/bg/office.jpg",
+    "bgm": "/bgm/d6.mp3",
+    "choices": [
+      { "text": "弁護士に相談して法的に戦う", "next": "consult_lawyer_first" },
+      { "text": "労働組合の結成を検討する", "next": "research_union" },
+      { "text": "労働基準監督署に駆け込む", "next": "labor_inspection" }
     ]
   },
 
@@ -214,7 +225,7 @@ export const storyData: StoryDataType = {
     "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
-      { "text": "断固として断る", "next": "procrastinate" },
+      { "text": "断固として断る", "next": "refuse_boss_task" },
       { "text": "仕方なく付き合う", "next": "attend_drinking_with_boss" },
       { "text": "30分だけなら", "next": "thirty_minutes_condition" }
     ]
@@ -225,9 +236,9 @@ export const storyData: StoryDataType = {
     "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
-      { "text": "反論する", "next": "procrastinate" },
+      { "text": "反論する", "next": "refuse_boss_task" },
       { "text": "黙って聞く", "next": "listen_silently_to_lecture" },
-      { "text": "席を立つ", "next": "procrastinate" }
+      { "text": "席を立つ", "next": "refuse_boss_task" }
     ]
   },
 
@@ -244,13 +255,13 @@ export const storyData: StoryDataType = {
     "bgm": "/bgm/n43.mp3",
     "choices": [
       { "text": "お互い転職活動しようか", "next": "parting_and_cry_then_jobhunt" },
-      { "text": "お互い頑張ろうな", "next": "work_alone_suffer" },
+      { "text": "一人で頑張るしかない", "next": "work_alone_suffer" },
       { "text": "もう限界だ...", "next": "mental_breakdown" }
     ]
   },
 
   "parting_and_cry_then_jobhunt": {
-    "text": "「お互い頑張ろうな」\n\n後輩が角を曲がって見えなくなった。\n\nその瞬間俺は泣き崩れた。\n\n限界だった。この会社にいては、自分も後輩も潰れてしまう。\n\n何日か経った後、決断した。もう、この会社には居られない。\n\n転職活動を本格的に始めた。書類作成、面接の準備、企業研究……。後輩のためにも、自分のためにも、やり抜くしかない。\n\n数ヶ月後、面接の結果が返ってきた。\n\n「当社で働いていただきたいのですが......」\n\nついに、新しい職場への内定を手にした。今度こそ、働きやすい環境で、人間らしく働けるはずだ。\n\n退職届を出すときの部長の顔は、自分の記憶から消してしまった。\n\n新しい会社での初出勤。朝日が眩しく感じた。\n\n「やっと......自由になれた」\n\n深く息を吸った。新しい人生の始まりだ。\n\n【グッドエンド：転職成功で新たな人生へ】",
+    "text": "「お互い、転職活動しようか」\n\n後輩は驚いた顔をしたあと、ゆっくりと頷いた。\n\n「……はい、そうですね。先輩」\n\n短く返事をして、後輩が角を曲がって見えなくなった。\n\nその瞬間俺は泣き崩れた。\n\n限界だった。この会社にいては、自分も後輩も潰れてしまう。\n\n何日か経った後、決断した。もう、この会社には居られない。\n\n転職活動を本格的に始めた。書類作成、面接の準備、企業研究……。後輩のためにも、自分のためにも、やり抜くしかない。\n\n数ヶ月後、面接の結果が返ってきた。\n\n「当社で働いていただきたいのですが......」\n\nついに、新しい職場への内定を手にした。今度こそ、働きやすい環境で、人間らしく働けるはずだ。\n\n退職届を出すときの部長の顔は、自分の記憶から消してしまった。\n\n新しい会社での初出勤。朝日が眩しく感じた。\n\n「やっと......自由になれた」\n\n深く息を吸った。新しい人生の始まりだ。\n\n【グッドエンド：転職成功で新たな人生へ】",
     "background": "/images/bg/beach.jpg",
     "bgm": "/bgm/n99.mp3",
     "choices": []
@@ -776,7 +787,7 @@ export const storyData: StoryDataType = {
     "bgm": "/bgm/n99.mp3",
     "choices": [
       { "text": "労働組合を結成して全社改革を目指す", "next": "union_member_recruitment" },
-      { "text": "この改善で満足する", "next": "moderate_improvement_ending" },
+      { "text": "ここで戦いを終える", "next": "moderate_improvement_ending" },
       { "text": "改善の進捗を監視し続ける", "next": "monitor_company_improvement" }
     ]
   },
@@ -875,8 +886,8 @@ export const storyData: StoryDataType = {
     "bgm": "/bgm/n99.mp3",
     "choices": [
       { "text": "さらに組合を全社に拡大して根本改革", "next": "union_member_recruitment" },
-      { "text": "この改善で満足して働き続ける", "next": "moderate_improvement_ending" },
-      { "text": "改善された経験を活かして転職", "next": "job_search_burnout" }
+      { "text": "この成果で妥協する", "next": "moderate_improvement_ending" },
+      { "text": "せっかくの改善を捨てて転職に踏み切る", "next": "job_search_burnout" }
     ]
   },
 
@@ -885,7 +896,7 @@ export const storyData: StoryDataType = {
     "background": "/images/bg/new_office.jpg",
     "bgm": "/bgm/n99.mp3",
     "choices": [
-      { "text": "この改善に満足する", "next": "moderate_improvement_ending" }
+      { "text": "ここでひと区切りつける", "next": "moderate_improvement_ending" }
     ]
   },
 

--- a/src/data/story.ts
+++ b/src/data/story.ts
@@ -473,7 +473,7 @@ export const storyData: StoryDataType = {
 
   "company_wide_union": {
     "text": "1年間の戦いが、ついに実を結んだ。\n\n労働組合は全社に拡大し、従業員の8割が加入。会社との交渉を重ね、包括的な労働環境改革が実現した。\n\n残業代は法定通り支払われ、月給が平均5万円アップ。タバコ休憩は15分以内に制限され、飲み会の強制参加は完全に禁止。セクハラ・パワハラの相談窓口が設置され、有給取得率は90%以上に改善した。\n\n「あの時、一人で耐えずに声を上げて良かった」\n\n後輩が笑顔で定時退社する姿を見て、心から思う。\n\n組合委員長として、仲間と共に会社を変えることができた。これが、本当の勝利だ。\n\n【グッドエンド：労働組合で会社改革成功】",
-    "background": "/images/bg/new_office.jpg",
+    "background": "/images/bg/beach.jpg",
     "bgm": "/bgm/n99.mp3",
     "choices": []
   },
@@ -553,7 +553,7 @@ export const storyData: StoryDataType = {
 
   "plan_anonymous_report": {
     "text": "匿名申告について考えることにした。\n\n署員「申告者の特定は不要です。ただし、できれば証拠があると調査が進みやすくなります」\n\n「どんな証拠が必要ですか？」\n\n署員「給与明細、勤務時間の記録、パワハラの録音など、違反を証明するものなら何でもいいです」\n\n「準備して来月申告します」",
-    "background": "/images/bg/labor_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
       { "text": "証拠を集める", "next": "gather_evidence_carefully" },
@@ -648,7 +648,7 @@ export const storyData: StoryDataType = {
 
   "report_with_minimal_evidence": {
     "text": "給与明細だけで申告することにした。\n\n「早く動いた方が得策だ」\n\n労働基準監督署に申告を提出。\n\n署員「証拠は給与明細だけですか？」\n「はい。他の証拠は...」\n\n「少し弱いですが、調査は開始します」\n\n会社への調査は始まったが、強制力は弱いかもしれない。",
-    "background": "/images/bg/labor_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
       { "text": "追加の証拠をすぐに送る", "next": "rush_evidence_submission" },
@@ -718,7 +718,7 @@ export const storyData: StoryDataType = {
 
   "submit_evidence_report": {
     "text": "十分な証拠を集めて申告書を提出した。\n\n署員「このような詳しい記録はいいですね。調査が進みやすくなります」\n\n2週間後、会社に是正勧告が届いた。\n\n会社側も無視できない状況になった。",
-    "background": "/images/bg/labor_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
       { "text": "会社の改善状況を見守る", "next": "continue_improved_company" },
@@ -740,7 +740,7 @@ export const storyData: StoryDataType = {
 
   "rush_evidence_submission": {
     "text": "追加の証拠をすぐに労働基準監督署に送ることにした。\n\n署員「ああ、これで強制力が出てきますね」\n\n追加の録音やメール記録で、会社の違法性が明確になった。\n\n署員「これは指導だけでは済みませんね。最低でも是正勧告を出します」",
-    "background": "/images/bg/labor_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
       { "text": "是正勧告を見守る", "next": "continue_improved_company" },
@@ -751,7 +751,7 @@ export const storyData: StoryDataType = {
 
   "multi_person_report": {
     "text": "複数人での申告で力を強めることにした。\n\n同期の他に、後輩も申告に参加することにした。\n\n3人での申告により、労働基準監督署も全社調査に乗り出した。\n\n「複数人だと説得力が違う」\n\nさらに行動を起こすべきか？",
-    "background": "/images/bg/labor_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n43.mp3",
     "choices": [
       { "text": "この機会に労働組合を正式に結成", "next": "form_union_three" },
@@ -783,7 +783,7 @@ export const storyData: StoryDataType = {
 
   "lawyer_gradual_success": {
     "text": "段階的改善を受け入れることにした。\n\n第1段階：残業代の適正支払い開始\n第2段階（3ヶ月後）：パワハラ対策の強化\n第3段階（6ヶ月後）：有給取得率80%以上を実現\n\n実際に改善が進み始めた。段階的ですが、確実な前進だ。\n\nこの勢いでさらなる改革を進めるべきか？",
-    "background": "/images/bg/new_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n99.mp3",
     "choices": [
       { "text": "労働組合を結成して全社改革を目指す", "next": "union_member_recruitment" },
@@ -882,7 +882,7 @@ export const storyData: StoryDataType = {
 
   "monitor_company_improvement": {
     "text": "会社の改善状況を監視することにした。\n\n・残業代の支払い: 完全に支払われるように改善\n・パワハラの相談窓口: 設置完了\n・有給取得率: 80%以上に改善\n\nようやく普通の労働環境になり始めた。\n\nしかし、これで本当に十分だろうか？",
-    "background": "/images/bg/new_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n99.mp3",
     "choices": [
       { "text": "さらに組合を全社に拡大して根本改革", "next": "union_member_recruitment" },
@@ -893,7 +893,7 @@ export const storyData: StoryDataType = {
 
   "continue_improved_company": {
     "text": "改善された会社で働き続けることにした。\n\n・月給が5万円アップ（適正な残業代支払い）\n・定時退社が当たり前に\n・有給取得率90%以上\n・ハラスメント防止体制の確立\n・働きやすい職場環境\n\n部長「お前のおかげで、この会社は良くなったな」\n\n「当たり前のことをしただけです」",
-    "background": "/images/bg/new_office.jpg",
+    "background": "/images/bg/office.jpg",
     "bgm": "/bgm/n99.mp3",
     "choices": [
       { "text": "ここでひと区切りつける", "next": "moderate_improvement_ending" }


### PR DESCRIPTION
## 概要
ストーリーに新しいシーン「refuse_boss_task」を追加し、部長に逆らった場合のパワハラ報復シナリオを実装。複数の既存シーンからこの新シーンへのルーティングを修正し、ストーリーの選択肢テキストを改善してナラティブの一貫性を強化しました。

## 変更内容
- **新シーン追加**: `refuse_boss_task` - 部長の無理な指示に反発した主人公がパワハラを受けるシーン。弁護士相談、労働組合結成、労基署申告の3つの対抗手段を提示
- **ルーティング修正**: 
  - `receive_document_task` の2つの選択肢を `procrastinate` から `refuse_boss_task` へ変更
  - `work_with_junior` の「断固として断る」を `refuse_boss_task` へ変更
  - `attend_drinking_with_boss` の「反論する」「席を立つ」を `refuse_boss_task` へ変更
- **選択肢テキスト改善**:
  - 「本格的に転職活動を開始する」→「勢いで本格的に転職活動を始める」
  - 「転職エージェントに相談する」→「焦って転職エージェントに駆け込む」
  - 「お互い頑張ろうな」→「一人で頑張るしかない」
  - その他複数の選択肢テキストを改善
- **背景画像修正**: 複数のシーンで `new_office.jpg` を `office.jpg` に統一、`labor_office.jpg` を `office.jpg` に変更
- **ストーリーテキスト改善**: 
  - `parting_and_cry_then_jobhunt` の冒頭を改善
  - `accept_overtime_daily` の描写を詳細化
- **ドキュメント更新**: STORY_FLOW.md の総シーン数を113から114に更新、フローチャートを修正

## 動機・背景
既存の `procrastinate` シーンは「先延ばし」という概念を表していましたが、実際には部長に逆らってパワハラを受けるシナリオに使用されていました。この矛盾を解決するため、専用の `refuse_boss_task` シーンを作成し、パワハラ報復と対抗手段を明確に描写することで、ストーリーの論理性と選択肢の意味を改善しました。また、選択肢テキストを改善することで、プレイヤーの意思決定がより明確に反映されるようにしました。

## テスト
- [ ] ユニットテスト
- [ ] 統合テスト
- [x] 手動テスト - 新シーンへのルーティングが正常に機能することを確認

## チェックリスト
- [ ] CodeRabbitで問題がない
- [ ] `npm run build`で問題が出ない
- [ ] Vercel botで問題が出ない
- [ ] テストが通る
- [x] ドキュメントを更新した（STORY_FLOW.md）

https://claude.ai/code/session_015FRqNEvErb7gqjhZgZ7C8K